### PR TITLE
0.5.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.gem
+*.html
 .bundle
 Gemfile.lock
 pkg/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,13 @@
 ---
 AllCops:
+  DisplayCopNames: true
   TargetRubyVersion: 2.3
   Exclude:
   - Gemfile
   - Rakefile
   - 'test/**/*'
   - 'lib/plugins/*/test/**/*'
+  - 'lib/plugins/inspec-init/templates/**/*'
   # This is delicate; we want to include examples/plugins/*/lib
   # but not anything else.
   - 'examples/*profile*/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,10 @@ Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
   Max: 11
+Naming/FileName:
+  Enabled: false
+Naming/PredicateName:
+  Enabled: false
 NumericLiterals:
   MinDigits: 10
 Security/YAMLLoad:
@@ -69,13 +73,13 @@ Style/EmptyMethod:
   Enabled: false
 Style/Encoding:
   Enabled: false
-Style/FileName:
-  Enabled: false
 Style/GuardClause:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
-Style/MethodMissing:
+Style/MethodMissingSuper:
+  Enabled: false
+Style/MissingRespondToMissing:
   Enabled: false
 Style/MultilineIfModifier:
   Enabled: false
@@ -98,13 +102,11 @@ Style/PercentLiteralDelimiters:
     '%w': '{}'
     '%W': ()
     '%x': ()
-Style/PredicateName:
-  Enabled: false
 Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 Style/UnlessElse:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,14 @@ AllCops:
   - Gemfile
   - Rakefile
   - 'test/**/*'
-  - 'examples/**/*'
+  - 'lib/plugins/*/test/**/*'
+  # This is delicate; we want to include examples/plugins/*/lib
+  # but not anything else.
+  - 'examples/*profile*/**/*'
+  - 'examples/kitchen*/**/*'
+  - 'examples/inheritance/**/*'
+  - 'examples/custom-resource/**/*'
+  - 'examples/plugins/*/test/**/*'
   - 'vendor/**/*'
   - 'lib/bundles/inspec-init/templates/**/*'
   - 'www/demo/**/*'
@@ -44,10 +51,6 @@ Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
   Max: 11
-Naming/FileName:
-  Enabled: false
-Naming/PredicateName:
-  Enabled: false
 NumericLiterals:
   MinDigits: 10
 Security/YAMLLoad:
@@ -63,6 +66,8 @@ Style/ConditionalAssignment:
 Style/EmptyMethod:
   Enabled: false
 Style/Encoding:
+  Enabled: false
+Style/FileName:
   Enabled: false
 Style/GuardClause:
   Enabled: false
@@ -91,13 +96,13 @@ Style/PercentLiteralDelimiters:
     '%w': '{}'
     '%W': ()
     '%x': ()
+Style/PredicateName:
+  Enabled: false
 Style/SymbolArray:
   Enabled: false
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInHashLiteral:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 Style/UnlessElse:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.4.3
   - 2.5.1
+  - 2.6.0
 script:
-  - bundle exec rubocop
-  - bundle exec rspec
+  - bundle exec rake lint
+  - bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,22 +38,21 @@ This is the current, previous and future development milestones and contains the
 * Sync and upgrade InSpec's .rubocop.yml and associated code cleanups
 * rename lib/inspec-iggy/profile.rb to profile_helper.rb
 * refactor out JSON parsing into file_helper.rb
+* switch from 'eq' to 'cmp' comparators https://github.com/mattray/inspec-iggy/issues/23
+* add support for remote .tfstate and .cfn files via Iggy::FileHelper.fetch https://github.com/mattray/inspec-iggy/issues/3
 
-* add support for remote .tfstate and .cfn files
-https://github.com/mattray/inspec-iggy/issues/3
 * document Windows Omnibus installer usage
-* Test with something besides AWS AZURE
+* Test with something besides AWS AZURE GCP
 
 # BACKLOG #
 * Habitat packaging
-* functional tests
 * Rubocop the generated profiles
+* enable negative testing to look for things not covered by Terraform
 * ARM templates
-* create a Terraform Provisioner for attaching InSpec profiles to a resource
-* Generate a full profile that depends on the list of profiles from tags
-* Tie tagged compliance profiles back to machines and non-machines where applicable (ie. AWS Hong Kong)
-* Test with more complicated tfstate files, the parsing is probably brittle
-* negative testing
-* do we want to generate inspec coverage for the tfplan?
+* Terraform
+  * Test with more complicated tfstate files, the parsing is probably brittle
+  * do we want to generate inspec coverage for the tfplan?
+  * Terraform 0.12 support
 * restore extract functionality
-* terraform 0.12 support
+  * create a Terraform Provisioner for attaching InSpec profiles to a resource
+  * Tie tagged compliance profiles back to machines and non-machines where applicable (ie. AWS Hong Kong)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,13 @@ This is the current, previous and future development milestones and contains the
 * Expand Rakefile
 
 # 0.5.0
-* provide DESIGN.md explaining the organization of the code
+* provide DESIGN.md explaining the organization of the codeo
 * disabled the `inspec terraform extract` subcommand until a more sustainable solution is determined
 * moved back to https://github.com/mattray/inspec-iggy as a community plugin
 * Sync and upgrade InSpec's .rubocop.yml and associated code cleanups
+* rename lib/inspec-iggy/profile.rb to profile_helper.rb
 
 * refactor out JSON parsing into helper with support for remote .tfstate and .cfn files
-* rename lib/inspec-iggy/parser.rb to parser_helper.rb
 https://github.com/mattray/inspec-iggy/issues/3
 * document Windows Omnibus installer usage
 * Test with something besides AWS AZURE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,20 +39,29 @@ This is the current, previous and future development milestones and contains the
 * rename lib/inspec-iggy/profile.rb to profile_helper.rb
 * refactor out JSON parsing into file_helper.rb
 * switch from 'eq' to 'cmp' comparators https://github.com/mattray/inspec-iggy/issues/23
+* enable minimal Azure support. This needs to be refactored.
 * add support for remote .tfstate and .cfn files via Iggy::FileHelper.fetch https://github.com/mattray/inspec-iggy/issues/3
+  http://
+  https://
+  s3://MyAstmazonS3BucketName/MyFileName.json
 
 * document Windows Omnibus installer usage
-* Test with something besides AWS AZURE GCP
 
 # BACKLOG #
+* how are we going to preemptively know what's in the various resource packs?
+  Perhaps load all Resources individually to map out their properties?
+  Big translation helper hash?
+* enable GCP support
 * Habitat packaging
 * Rubocop the generated profiles
 * enable negative testing to look for things not covered by Terraform
 * ARM templates
+* translate properties from cfn/tf->inspec
 * Terraform
-  * Test with more complicated tfstate files, the parsing is probably brittle
+  * More Terraform back-ends https://www.terraform.io/docs/backends/types/index.html
   * do we want to generate inspec coverage for the tfplan?
   * Terraform 0.12 support
 * restore extract functionality
   * create a Terraform Provisioner for attaching InSpec profiles to a resource
   * Tie tagged compliance profiles back to machines and non-machines where applicable (ie. AWS Hong Kong)
+* InSpec 4.0 will likely break stuff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This is the current, previous and future development milestones and contains the
 * Expand Rakefile
 
 # 0.5.0
-* provide DESIGN.md explaining the organization of the codeo
+* provide DESIGN.md explaining the organization of the code
 * disabled the `inspec terraform extract` subcommand until a more sustainable solution is determined
 * moved back to https://github.com/mattray/inspec-iggy as a community plugin
 * Sync and upgrade InSpec's .rubocop.yml and associated code cleanups

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,9 @@ This is the current, previous and future development milestones and contains the
 * moved back to https://github.com/mattray/inspec-iggy as a community plugin
 * Sync and upgrade InSpec's .rubocop.yml and associated code cleanups
 * rename lib/inspec-iggy/profile.rb to profile_helper.rb
+* refactor out JSON parsing into file_helper.rb
 
-* refactor out JSON parsing into helper with support for remote .tfstate and .cfn files
+* add support for remote .tfstate and .cfn files
 https://github.com/mattray/inspec-iggy/issues/3
 * document Windows Omnibus installer usage
 * Test with something besides AWS AZURE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,9 @@ This is the current, previous and future development milestones and contains the
 * switch from 'eq' to 'cmp' comparators https://github.com/mattray/inspec-iggy/issues/23
 * enable minimal Azure support. This needs to be refactored.
 * add support for remote .tfstate and .cfn files via Iggy::FileHelper.fetch https://github.com/mattray/inspec-iggy/issues/3
-  http://
-  https://
-  s3://MyAstmazonS3BucketName/MyFileName.json
-
-* document Windows Omnibus installer usage
 
 # BACKLOG #
+* document Windows Omnibus installer usage
 * how are we going to preemptively know what's in the various resource packs?
   Perhaps load all Resources individually to map out their properties?
   Big translation helper hash?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,19 @@ This is the current, previous and future development milestones and contains the
 * Add tests for testing user functionality
 * Expand Rakefile
 
-# BACKLOG #
+# 0.5.0
+* provide DESIGN.md explaining the organization of the code
+* disabled the `inspec terraform extract` subcommand until a more sustainable solution is determined
+* moved back to https://github.com/mattray/inspec-iggy as a community plugin
+* Sync and upgrade InSpec's .rubocop.yml and associated code cleanups
+
+* refactor out JSON parsing into helper with support for remote .tfstate and .cfn files
+* rename lib/inspec-iggy/parser.rb to parser_helper.rb
+https://github.com/mattray/inspec-iggy/issues/3
 * document Windows Omnibus installer usage
+* Test with something besides AWS AZURE
+
+# BACKLOG #
 * Habitat packaging
 * functional tests
 * Rubocop the generated profiles
@@ -40,6 +51,8 @@ This is the current, previous and future development milestones and contains the
 * create a Terraform Provisioner for attaching InSpec profiles to a resource
 * Generate a full profile that depends on the list of profiles from tags
 * Tie tagged compliance profiles back to machines and non-machines where applicable (ie. AWS Hong Kong)
-* Test with something besides AWS
 * Test with more complicated tfstate files, the parsing is probably brittle
 * negative testing
+* do we want to generate inspec coverage for the tfplan?
+* restore extract functionality
+* terraform 0.12 support

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,6 +74,10 @@ The CFN parser is very similar to the [terraform/parser.rb](#tf_parse), parsing 
 
 # Helpers
 
+## [lib/inspec-iggy/file_helper.rb](lib/inspec-iggy/file_helper.rb)<a name="file_helper"/>
+
+Helper class that parses JSON input files and handles errors.
+
 ## [lib/inspec-iggy/inspec_helper.rb](lib/inspec-iggy/inspec_helper.rb)<a name="inspec_helper"/>
 
 Constants and helpers for working with InSpec. The full list of available InSpec Resources are provided by the `RESOURCES` array. Resources that do not map cleanly are provided by the `TRANSLATED_RESOURCES` hash. There are very few mismatches because both tools use the SDKs provided by the same vendors.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2,6 +2,8 @@
 
 This document attempts to explain the organization of the InSpec-Iggy code and how to extend it as necessary. Because Iggy is an InSpec plugin, it tries to follow InSpec closely with regards to versions, style, and tooling. Links to the source code are given because there may be additional documentation within the files.
 
+# Files
+
 * [inspec-iggy.gemspec](#gemspec)
 * [.rubocop.yml](#rubocop)
 * [lib/inspec-iggy.rb](#iggy)
@@ -13,8 +15,6 @@ This document attempts to explain the organization of the InSpec-Iggy code and h
 * [lib/inspec-iggy/inspec_helper.rb](#inspec_helper)
 * [lib/inspec-iggy/profile_helper.rb](#profile_helper)
 * [lib/inspec-iggy/version.rb](#version)
-
-# Base Files
 
 ## [inspec-iggy.gemspec](inspec-iggy.gemspec)<a name="gemspec"/>
 
@@ -95,3 +95,23 @@ Helper class to render a full InSpec profile with a `README.md`, `inspec.yml`, a
 ## [lib/inspec-iggy/version.rb](lib/inspec-iggy/version.rb)<a name="version"/>
 
 Tracks the version of InSpec-Iggy.
+
+# Platform Support
+
+## Terraform
+
+For InSpec-Iggy to work, you must have both Terraform and InSpec support for your platform. This is because it maps Terraform resources to InSpec resources. If there's not an InSpec plugin for the platform, there won't be any resources generated.
+
+If you have working InSpec and Terraform support, you will want to run with
+
+    inspec terraform generate -t terraform.tfstate --name DEBUG --debug
+
+and look for messages with `Iggy::Terraform.parse_generate` to see what is being `SKIPPED`, `TRANSLATED` or `MATCHED`. You may want to drop a `pry` debugging breakpoint within the [Terraform parser](#tf_parse) `parse_generate` method to see what is in the JSON versus what InSpec resources.
+
+If you are not getting `MATCHED` `tf_res_type` resources and all `SKIPPED`, they are most likely not in the `InspecPlugins::Iggy::InspecHelper::RESOURCES`. The `TRANSLATED_RESOURCES` within the [inspec_helper.rb](#inspec_helper) may need to be updated to map `tf_res_type`s to what is in InSpec.
+
+At this point there are not mappings for InSpec properties to Terraform attributes. If this is an issue an additional hash of resources and the attribute mapping could be added to the [inspec_helper.rb](#inspec_helper)) in the future.
+
+## Alternate Formats
+
+If you want to add support for another format (ie. ARM templates or something similar), follow the examples of the [Terraform](#tf) and [CloudFormation](#cfn) support. You will start by adding a new `cli_command` to the [lib/inspec-iggy/plugin.rb](#plugin). You will need a `cli_command.rb` and `parser.rb` implementing the appropriate classes and methods.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,93 @@
+# Design
+
+This document attempts to explain the organization of the InSpec-Iggy code and how to extend it as necessary. Because Iggy is an InSpec plugin, it tries to follow InSpec closely with regards to versions, style, and tooling. Links to the source code are given because there may be additional documentation within the files.
+
+* [inspec-iggy.gemspec](#gemspec)
+* [.rubocop.yml](#rubocop)
+* [lib/inspec-iggy.rb](#iggy)
+* [lib/inspec-iggy/plugin.rb](#plugin)
+* [lib/inspec-iggy/terraform/cli_command.rb](#tf_cli)
+* [lib/inspec-iggy/terraform/parser.rb](#tf_parse)
+* [lib/inspec-iggy/cloudformation/cli_command.rb](#cfn_cli)
+* [lib/inspec-iggy/cloudformation/parser.rb](#cfn_parse)
+* [lib/inspec-iggy/inspec_helper.rb](#inspec_helper)
+* [lib/inspec-iggy/profile.rb](#profile_helper)
+* [lib/inspec-iggy/version.rb](#version)
+
+# Base Files
+
+## [inspec-iggy.gemspec](inspec-iggy.gemspec)<a name="gemspec"/>
+
+ This is where metadata for the Gem goes. We have also pinned the version of InSpec to between 2.3 and less than 4.0 to prevent breaking changes.
+
+## [.rubocop.yml](.rubocop.yml)<a name="rubocop"/>
+
+Tracks against InSpec's settings for code style.
+
+## [lib/inspec-iggy.rb](lib/inspec-iggy.rb)<a name="iggy"/>
+
+This is the "entry point" for InSpec to load if it thinks the plugin is installed. The *only* thing this file should do is setup the load path, then load the plugin definition file.
+
+## [lib/inspec-iggy/plugin.rb](lib/inspec-iggy/plugin.rb)<a name="plugin"/>
+
+Plugin Definition file. The purpose of this file is to declare to InSpec what plugin_types (capabilities) are included in this plugin, and provide hooks that will load them as needed. It is important that this file load successfully and *quickly*. The plugin's functionality may never be used on this InSpec run; so we keep things fast and light by only loading heavy things when they are needed.
+
+The entry points for the `cli_command`s for `:terraform` and `:cloudformation` are here. If you were to add another format this is the place to declare that.
+
+# Terraform<a name="tf"/>
+
+## [lib/inspec-iggy/terraform/cli_command.rb](lib/inspec-iggy/terraform/cli_command.rb)<a name="tf_cli"/>
+
+The `inspec terraform` CLI command and options. Given this is a Thor CLI, the `desc` and `subcommand_desc` provide help at the CLI. The `option`s hash is used to define documentation and settings for allowed subcommand options. Each method (`generate` and `extract`) is turned into further subcommands (ie. `inspec terraform generate`). The `extract` command has been disabled until a better solution is available.
+
+Within the `generate` method the following block:
+
+    generated_controls = InspecPlugins::Iggy::Terraform::Parser.parse_generate(options[:tfstate])
+
+calls into the [Terraform tfstate file parser](#tf_parse) which returns the InSpec controls found by mapping Terraform resources to InSpec resources.
+
+    printable_controls = InspecPlugins::Iggy::InspecHelper.tf_controls(options[:title], generated_controls)
+
+calls into the [inspec helper](#inspec_helper) to produce the inspec controls to include within the profile.
+
+    inspecplugins::iggy::profile.render_profile(self, options, options[:tfstate], printable_controls)
+
+calls into the [profile renderer](#profile_helper).
+
+## [lib/inspec-iggy/terraform/parser.rb](lib/inspec-iggy/terraform/parser.rb)<a name="tf_parse"/>
+
+This class parses the passed Terraform .tfstate files. The `parse_generate` method is the standard interface for parsing, it calls into the private `parse_tfstate` method which reads the actual JSON.
+
+The parsed Terraform JSON has a `modules` array of `resources` which are then mapped to the appropriate InSpec Resources. The [TRANSLATED_RESOURCES](#inspec_helper) provide a mapping of Terraform resources that do not match the InSpec equivalent. Controls are generated for matched resources and if the InSpec properties match the named Terraform resource attributes tests are added. The generated InSpec controls are returned.
+
+The `parse_extract` command has been disabled until it can be properly refactored.
+
+# CloudFormation<a name="cfn"/>
+
+## [lib/inspec-iggy/cloudformation/cli_command.rb](lib/inspec-iggy/cloudformation/cli_command.rb)<a name="cfn_cli"/>
+
+The CFN `cli_command.rb` is similar to the [terraform/cli_command.rb](#tf_cli). It requires a `:stack` as an option, because it will dynamically generate the InSpec profile from the launched CloudFormation stack in conjunction with the template.
+
+## [lib/inspec-iggy/cloudformation/parser.rb](lib/inspec-iggy/cloudformation/parser.rb)<a name="cfn_parse"/>
+
+The CFN parser is very similar to the [terraform/parser.rb](#tf_parse), parsing a JSON template file and iterating over the 'Resources'.
+
+# Helpers
+
+## [lib/inspec-iggy/inspec_helper.rb](lib/inspec-iggy/inspec_helper.rb)<a name="inspec_helper"/>
+
+Constants and helpers for working with InSpec. The full list of available InSpec Resources are provided by the `RESOURCES` array. Resources that do not map cleanly are provided by the `TRANSLATED_RESOURCES` hash. There are very few mismatches because both tools use the SDKs provided by the same vendors.
+
+The `resources_properties` method returns the unique InSpec Resource properties of the passed resource. The `COMMON_PROPERTIES` array is a hack used to find the unique InSpec properties from overlapping class methods.
+
+The method `tf_controls` provides the content for the controls file for Terraform subcommand.
+
+The `cfn_controls` method provides the AWS API calls to dynamically check the passed CloudFormation stack and provide the content for the controls file.
+
+## [lib/inspec-iggy/profile.rb](lib/inspec-iggy/profile.rb)<a name="profile_helper"/>
+
+Helper class to render a full InSpec profile with a `README.md`, `inspec.yml`, and the generated `controls/controls.rb` populated from the parsed input file and the CLI options provided.
+
+## [lib/inspec-iggy/version.rb](lib/inspec-iggy/version.rb)<a name="version"/>
+
+Tracks the version of InSpec-Iggy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,7 @@ This document attempts to explain the organization of the InSpec-Iggy code and h
 * [lib/inspec-iggy/cloudformation/cli_command.rb](#cfn_cli)
 * [lib/inspec-iggy/cloudformation/parser.rb](#cfn_parse)
 * [lib/inspec-iggy/inspec_helper.rb](#inspec_helper)
-* [lib/inspec-iggy/profile.rb](#profile_helper)
+* [lib/inspec-iggy/profile_helper.rb](#profile_helper)
 * [lib/inspec-iggy/version.rb](#version)
 
 # Base Files
@@ -84,7 +84,7 @@ The method `tf_controls` provides the content for the controls file for Terrafor
 
 The `cfn_controls` method provides the AWS API calls to dynamically check the passed CloudFormation stack and provide the content for the controls file.
 
-## [lib/inspec-iggy/profile.rb](lib/inspec-iggy/profile.rb)<a name="profile_helper"/>
+## [lib/inspec-iggy/profile_helper.rb](lib/inspec-iggy/profile_helper.rb)<a name="profile_helper"/>
 
 Helper class to render a full InSpec profile with a `README.md`, `inspec.yml`, and the generated `controls/controls.rb` populated from the parsed input file and the CLI options provided.
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,15 +3,11 @@ source 'http://rubygems.org'
 
 gemspec
 
+# follows InSpec's versions
 group :test do
-  gem 'rake'              # Build task manager
-  gem 'chefstyle'
-  gem 'byebug'            # A debugger REPL
-  gem 'rubocop'           # Needed for style linting
+  gem 'minitest', '~> 5.5'
+  gem 'rake', '>= 10'
+  gem 'rubocop', '= 0.49.1'
   gem 'm'
-end
-
-group :tools do
-  gem 'github_changelog_generator'
-  gem 'rb-readline'
+  gem 'pry-byebug'
 end

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,201 @@
-Copyright (c) 2015 Chef Software Inc.
-Copyright (c) 2015 Vulcano Security GmbH.
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-       http://www.apache.org/licenses/LICENSE-2.0
+1. Definitions.
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Description #
 
-[![Build Status Master](https://travis-ci.org/inspec/inspec-iggy.svg?branch=master)](https://travis-ci.org/inspec/inspec-iggy)
+[![Build Status Master](https://travis-ci.org/mattray/inspec-iggy.svg?branch=master)](https://travis-ci.org/mattray/inspec-iggy)
 
 InSpec-Iggy (InSpec Generate -> "IG" -> "Iggy") is an [InSpec](https://inspec.io) plugin for generating compliance controls and profiles from [Terraform](https://terraform.io) `tfstate` files and [AWS CloudFormation](https://aws.amazon.com/cloudformation/) templates. Iggy generates InSpec controls by mapping Terraform and CloudFormation resources to InSpec resources and exports a profile that may be used from the `inspec` CLI or uploaded to [Chef Automate](https://automate.chef.io/).
 
@@ -10,20 +10,25 @@ InSpec-Iggy (InSpec Generate -> "IG" -> "Iggy") is an [InSpec](https://inspec.io
 
 Iggy was originally a stand-alone CLI inspired by Christoph Hartmann's [inspec-verify-provision](https://github.com/chris-rock/inspec-verify-provision) and the blog post on testing [InSpec for provisioning testing: Verify Terraform setups with InSpec](http://lollyrock.com/articles/inspec-terraform/).
 
-The [CHANGELOG.md](https://github.com/inspec/iggy/blob/master/CHANGELOG.md) covers current, previous and future development milestones and contains the features backlog.
+The [CHANGELOG.md](https://github.com/mattray/iggy/blob/master/CHANGELOG.md) covers current, previous and future development milestones and contains the features backlog.
 
 1. [Requirements](#requirements)
-2. [Installation](#installation)
-3. [InSpec Terraform Generate](#itg)
-4. [InSpec Terraform Extract](#ite)
-5. [InSpec Cloudformation Generate](#icg)
-6. [Testing](#testing)
+2. [Development and Support](#support)
+3. [Installation](#installation)
+4. [InSpec Terraform Generate](#itg)
+5. [InSpec Terraform Extract](#ite)
+6. [InSpec Cloudformation Generate](#icg)
+7. [Testing](#testing)
+
+# Development and Support<a name="support"></a>
+
+Iggy is a community-driven plugin that is not officially supported by Chef. We welcome patches, suggestions, and issues.
 
 # Requirements <a name="requirements"></a>
 
 Iggy generates compliance profiles for InSpec 2.3 and later, which includes the AWS and Azure resources. Because resources are continuing to be added to InSpec, you may want the latest version to support as many resource coverage as possible. It has currently been tested primarily with AWS but other InSpec-supported platforms should work as well.
 
-Written and tested with Ruby 2.5.1.
+Written and tested with Ruby 2.6.0.
 
 # Installation <a name="installation"></a>
 
@@ -121,7 +126,6 @@ $ inspec plugin install path/to/your/inspec-iggy/lib/inspec-iggy.rb
 
 # Testing Iggy<a name="testing"></a>
 
-
 Unit, Functional, and Integration tests are provided, though more are welcome. Iggy uses the Minitest library for testing, using the classic `def test...` syntax. Because Iggy loads InSpec into memory, and InSpec uses RSpec internally, Spec-style testing breaks.
 
 To run all tests, run
@@ -149,7 +153,7 @@ $ bundle exec rubocop -a
 |                |                                           |
 |:---------------|:------------------------------------------|
 | **Author**     | Matt Ray (<matt@chef.io>)                 |
-| **Copyright:** | Copyright (c) 2017-2018 Chef Software Inc.|
+| **Copyright:** | Copyright (c) 2017-2019 Chef Software Inc.|
 | **License:**   | Apache License, Version 2.0               |
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/README.md
+++ b/README.md
@@ -13,34 +13,31 @@ Iggy was originally a stand-alone CLI inspired by Christoph Hartmann's [inspec-v
 The [CHANGELOG.md](https://github.com/mattray/iggy/blob/master/CHANGELOG.md) covers current, previous and future development milestones and contains the features backlog.
 
 1. [Requirements](#requirements)
-2. [Development and Support](#support)
+2. [Support](#support)
 3. [Installation](#installation)
 4. [InSpec Terraform Generate](#itg)
-5. [InSpec Terraform Extract](#ite)
-6. [InSpec Cloudformation Generate](#icg)
-7. [Testing](#testing)
+5. [InSpec Cloudformation Generate](#icg)
+6. [Development and Testing](#development)
 
-# Development and Support<a name="support"></a>
+# Support<a name="support"></a>
 
-Iggy is a community-driven plugin that is not officially supported by Chef. We welcome patches, suggestions, and issues.
+InSpec-Iggy is a community-driven plugin that is not officially supported by Chef. We welcome patches, suggestions, and issues.
 
 # Requirements <a name="requirements"></a>
 
-Iggy generates compliance profiles for InSpec 2.3 and later, which includes the AWS and Azure resources. Because resources are continuing to be added to InSpec, you may want the latest version to support as many resource coverage as possible. It has currently been tested primarily with AWS but other InSpec-supported platforms should work as well.
+Iggy generates compliance profiles for InSpec 2.3 and later, which includes the AWS and Azure resources. Because resources are continuing to be added to InSpec, you may want the latest version to support as much resource coverage as possible. It has currently been tested primarily with AWS but other InSpec-supported platforms should work as well.
 
-Written and tested with Ruby 2.6.0.
+Written and tested with Ruby 2.6.
 
 # Installation <a name="installation"></a>
 
 `inspec-iggy` is a plugin for InSpec.  InSpec 2.3 or later is required.  To install, use:
 
-```
-$ inspec plugin install inspec-iggy
-```
+    $ inspec plugin install inspec-iggy
 
 # InSpec Terraform Generate<a name="itg"></a>
 
-     inspec terraform generate --tfstate terraform.tfstate --name myprofile
+    inspec terraform generate --tfstate terraform.tfstate --name myprofile
 
 Iggy dynamically pulls the available AWS resources from InSpec and attempts to map them to Terraform resources, producing an InSpec profile. ```inspec terraform generate --help``` will show all available options.
 
@@ -50,7 +47,6 @@ Iggy dynamically pulls the available AWS resources from InSpec and attempts to m
 
      -n, --name=NAME                  Name of profile to be generated (required)
      -t, [--tfstate=TFSTATE]          Specify path to the input terraform.tfstate (default: .)
-     [--debug], [--no-debug]          Verbose debugging messages
      [--copyright=COPYRIGHT]          Name of the copyright holder (default: The Authors)
      [--email=EMAIL]                  Email address of the author (default: you@example.com)
      [--license=LICENSE]              License for the profile (default: Apache-2.0)
@@ -59,37 +55,9 @@ Iggy dynamically pulls the available AWS resources from InSpec and attempts to m
      [--title=TITLE]                  Human-readable name for the profile (default: InSpec Profile)
      [--version=VERSION]              Specify the profile version (default: 0.1.0)
      [--overwrite], [--no-overwrite]  Overwrites existing profile directory
-
-# InSpec Terraform Extract (EXPERIMENTAL)<a name="ite"></a>
-
-    inspec terraform extract --tfstate terraform.tfstate
-
-## Tagging Profiles for Extract ##
-
-Compliance profiles are added to the Terraform Resource to be tested. The current 2 options are the ```aws_vpc``` or the ```aws_instance```. By tagging the ```aws_vpc``` you are specifying that the test is against the AWS API rather than individual machines. AWS instances tagged with compliance profiles will attempt to form command lines for ```inspec exec``` against them.
-
-### Tagging Format ###
-
-Given there is not support for lists within AWS tags, we use the convention of starting our tag names with ```inspec_name_``` and ```inspec_url_```. These are extracted and split to identify the relevant compliance profiles to run.
-
-```
-tags {
-    iggy_name_apache_baseline = "apache-baseline",
-    iggy_url_apache_baseline = "https://github.com/dev-sec/apache-baseline",
-    iggy_name_linux_baseline = "linux-baseline",
-    iggy_url_linux_baseline = "https://github.com/dev-sec/linux-baseline"
-}
-```
-
-### Potential Enhancements ###
-
-The current tagging for extraction implementation is directly tied to AWS. Other platforms such as Azure undoubtedly behave differently. Longterm this functionality should probably be turned into a Terraform Provider with predefined outputs.
-
-Subnet might be a better choice for tagging than VPCs, given they list the AZ.
-
-Currently it only supports URL-based compliance profiles. InSpec supports other formats (git, path, supermarket, compliance).
-
-inspec exec https://github.com/dev-sec/linux-baseline -t ssh://clckwrk@52.33.203.34 -i ~/.ssh/mattray-apac
+     [--debug], [--no-debug]          Verbose debugging messages
+     [--log-level=LOG_LEVEL]          Set the log level: info (default), debug, warn, error
+     [--log-location=LOG_LOCATION]    Location to send diagnostic log messages to. (default: STDOUT or Inspec::Log.error)
 
 # InSpec CloudFormation Generate<a name="icg"></a>
 
@@ -104,7 +72,6 @@ Iggy supports AWS CloudFormation templates by mapping the AWS resources to InSpe
      -n, --name=NAME                  Name of profile to be generated (required)
      -s, --stack=STACK                Specify stack name or unique stack ID associated with the CloudFormation template
      -t, --template=TEMPLATE          Specify path to the input CloudFormation template
-     [--debug], [--no-debug]          Verbose debugging messages
      [--copyright=COPYRIGHT]          Name of the copyright holder (default: The Authors)
      [--email=EMAIL]                  Email address of the author (default: you@example.com)
      [--license=LICENSE]              License for the profile (default: Apache-2.0)
@@ -113,40 +80,37 @@ Iggy supports AWS CloudFormation templates by mapping the AWS resources to InSpe
      [--title=TITLE]                  Human-readable name for the profile (default: InSpec Profile)
      [--version=VERSION]              Specify the profile version (default: 0.1.0)
      [--overwrite], [--no-overwrite]  Overwrites existing profile directory
+     [--debug], [--no-debug]          Verbose debugging messages
+     [--log-level=LOG_LEVEL]          Set the log level: info (default), debug, warn, error
+     [--log-location=LOG_LOCATION]    Location to send diagnostic log messages to. (default: STDOUT or Inspec::Log.error)
 
-# Development
+# Development and Testing<a name="development"></a>
+
+The [DESIGN.md](DESIGN.md) file outlines how the code is structured if you wish to extend functionality. We welcome patches, suggestions, and issues.
 
 ## Installation
 
 To point `inspec` at a local copy of `inspec-iggy` for development, use:
 
-```
-$ inspec plugin install path/to/your/inspec-iggy/lib/inspec-iggy.rb
-```
+    $ inspec plugin install path/to/your/inspec-iggy/lib/inspec-iggy.rb
 
-# Testing Iggy<a name="testing"></a>
+## Testing Iggy
 
 Unit, Functional, and Integration tests are provided, though more are welcome. Iggy uses the Minitest library for testing, using the classic `def test...` syntax. Because Iggy loads InSpec into memory, and InSpec uses RSpec internally, Spec-style testing breaks.
 
 To run all tests, run
 
-```
-$ bundle exec rake test
-```
+    $ bundle exec rake test
 
 Linting is also provided via Rubocop.
 
 To check for code style issues, run:
 
-```
-$ bundle exec rake lint
-```
+    $ bundle exec rake lint
 
 You can auto-correct many issues:
 
-```
-$ bundle exec rubocop -a
-```
+    $ bundle exec rake lint:auto_correct
 
 # License and Author #
 

--- a/inspec-iggy.gemspec
+++ b/inspec-iggy.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |spec|
   spec.version     = InspecPlugins::Iggy::VERSION
   spec.authors     = ['Matt Ray']
   spec.email       = ['matt@chef.io']
-  spec.summary     = 'InSpec plugin to generate InSpec compliance profiles from Terraform.'
-  spec.description = 'Generate InSpec compliance profiles from Terraform by tagging instances and mapping Terraform to InSpec.'
-  spec.homepage    = 'https://github.com/inspec/inspec-iggy'
+  spec.summary     = 'InSpec plugin to generate InSpec compliance profiles from Terraform and CloudFormation.'
+  spec.description = 'InSpec plugin to generate InSpec compliance profiles from Terraform and CloudFormation.'
+  spec.homepage    = 'https://github.com/mattray/inspec-iggy'
   spec.license     = 'Apache-2.0'
 
   spec.files = %w{

--- a/lib/inspec-iggy.rb
+++ b/lib/inspec-iggy.rb
@@ -1,15 +1,7 @@
-# encoding: utf-8
-
-# This file is known as the "entry point."
-# This is the file InSpec will try to load if it
-# thinks your plugin is installed.
-
-# The *only* thing this file should do is setup the
-# load path, then load the plugin definition file.
-
 # Next two lines simply add the path of the gem to the load path.
 # This is not needed when being loaded as a gem; but when doing
-# plugin development, you may need it.  Either way, it's harmless.
+# plugin development, you may need it. Either way, it's harmless.
+
 libdir = File.dirname(__FILE__)
 $LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
 

--- a/lib/inspec-iggy/cloudformation/cli_command.rb
+++ b/lib/inspec-iggy/cloudformation/cli_command.rb
@@ -1,9 +1,4 @@
-# encoding: utf-8
-#
-# Author:: Matt Ray (<matt@chef.io>)
-#
-# Copyright:: 2018, Chef Software, Inc <legal@chef.io>
-#
+# CloudFormation CLI command and options
 
 require 'inspec/plugin/v2'
 
@@ -14,7 +9,7 @@ require 'inspec-iggy/cloudformation/parser'
 module InspecPlugins::Iggy
   module CloudFormation
     class CliCommand < Inspec.plugin(2, :cli_command)
-      subcommand_desc 'cloudformation SUBCOMMAND ...', 'Generate InSpec from CloudFormation'
+      subcommand_desc 'cloudformation SUBCOMMAND ...', 'Generate an InSpec profile from CloudFormation'
 
       # Thor.map(Hash) allows you to make aliases for commands.
       map('-v' => 'version')         # Treat `inspec terraform -v`` as `inspec terraform version`

--- a/lib/inspec-iggy/cloudformation/cli_command.rb
+++ b/lib/inspec-iggy/cloudformation/cli_command.rb
@@ -3,7 +3,7 @@
 require 'inspec/plugin/v2'
 
 require 'inspec-iggy/version'
-require 'inspec-iggy/profile'
+require 'inspec-iggy/profile_helper'
 require 'inspec-iggy/cloudformation/parser'
 
 module InspecPlugins::Iggy
@@ -79,7 +79,7 @@ module InspecPlugins::Iggy
         # hash of generated controls
         generated_controls = InspecPlugins::Iggy::CloudFormation::Parser.parse_generate(options[:template])
         printable_controls = InspecPlugins::Iggy::InspecHelper.cfn_controls(options[:title], generated_controls, options[:stack])
-        InspecPlugins::Iggy::Profile.render_profile(self, options, options[:template], printable_controls)
+        InspecPlugins::Iggy::ProfileHelper.render_profile(self, options, options[:template], printable_controls)
         exit 0
       end
     end

--- a/lib/inspec-iggy/cloudformation/parser.rb
+++ b/lib/inspec-iggy/cloudformation/parser.rb
@@ -1,18 +1,17 @@
 # parses CloudFormation JSON files
 
-require 'json'
-
 require 'inspec/objects/control'
 require 'inspec/objects/ruby_helper'
 require 'inspec/objects/describe'
 
+require 'inspec-iggy/file_helper'
 require 'inspec-iggy/inspec_helper'
 
 module InspecPlugins::Iggy::CloudFormation
   class Parser
     # parse through the JSON and generate InSpec controls
     def self.parse_generate(file) # rubocop:disable all
-      template = parse_cfn(file)
+      template = InspecPlugins::Iggy::FileHelper.parse_json(file)
       absolutename = File.absolute_path(file)
 
       # InSpec controls generated
@@ -89,22 +88,6 @@ module InspecPlugins::Iggy::CloudFormation
       end
       Inspec::Log.debug "CloudFormation.parse_generate generated_controls = #{generated_controls}"
       generated_controls
-    end
-
-    # boilerplate JSON parsing
-    def self.parse_cfn(file)
-      Inspec::Log.debug "CloudFormation.parse_cfn file = #{file}"
-      begin
-        unless File.file?(file)
-          STDERR.puts "ERROR: #{file} is an invalid file, please check your path."
-          exit(-1)
-        end
-        JSON.parse(File.read(file))
-      rescue JSON::ParserError => e
-        STDERR.puts e.message
-        STDERR.puts "ERROR: Parsing error in #{file}."
-        exit(-1)
-      end
     end
   end
 end

--- a/lib/inspec-iggy/cloudformation/parser.rb
+++ b/lib/inspec-iggy/cloudformation/parser.rb
@@ -34,7 +34,7 @@ module InspecPlugins::Iggy::CloudFormation
 
         # does this match an InSpec resource?
         if InspecPlugins::Iggy::InspecHelper::RESOURCES.include?(cfn_res_type)
-          Inspec::Log.debug "CloudFormation.parse_generate cfn_res_type = #{cfn_res_type} MATCH"
+          Inspec::Log.debug "CloudFormation.parse_generate cfn_res_type = #{cfn_res_type} MATCHED"
 
           # insert new control based off the resource's ID
           ctrl = Inspec::Control.new
@@ -60,7 +60,7 @@ module InspecPlugins::Iggy::CloudFormation
             attr_split = attr.split(/(?=[A-Z])/)
             property = attr_split.join('_').downcase
             if inspec_properties.member?(property)
-              Inspec::Log.debug "CloudFormation.parse_generate #{cfn_res_type} inspec_property = #{property} MATCH"
+              Inspec::Log.debug "CloudFormation.parse_generate #{cfn_res_type} inspec_property = #{property} MATCHED"
               value = cfn_resources[cfn_res]['Properties'][attr]
               if (value.is_a? Hash) || (value.is_a? Array)
                 #  these get replaced at inspec exec
@@ -78,13 +78,13 @@ module InspecPlugins::Iggy::CloudFormation
                 describe.add_test(property, 'cmp', value)
               end
             else
-              Inspec::Log.debug "CloudFormation.parse_generate #{cfn_res_type} inspec_property = #{property} SKIP"
+              Inspec::Log.debug "CloudFormation.parse_generate #{cfn_res_type} inspec_property = #{property} SKIPPED"
             end
           end
           ctrl.add_test(describe)
           generated_controls.push(ctrl)
         else
-          Inspec::Log.debug "CloudFormation.parse_generate cfn_res_type = #{cfn_res_type} SKIP"
+          Inspec::Log.debug "CloudFormation.parse_generate cfn_res_type = #{cfn_res_type} SKIPPED"
         end
       end
       Inspec::Log.debug "CloudFormation.parse_generate generated_controls = #{generated_controls}"

--- a/lib/inspec-iggy/cloudformation/parser.rb
+++ b/lib/inspec-iggy/cloudformation/parser.rb
@@ -10,7 +10,7 @@ require 'inspec-iggy/inspec_helper'
 module InspecPlugins::Iggy::CloudFormation
   class Parser
     # parse through the JSON and generate InSpec controls
-    def self.parse_generate(cfn_template)
+    def self.parse_generate(cfn_template) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       template = InspecPlugins::Iggy::FileHelper.parse_json(cfn_template)
       absolutename = File.absolute_path(cfn_template)
 

--- a/lib/inspec-iggy/cloudformation/parser.rb
+++ b/lib/inspec-iggy/cloudformation/parser.rb
@@ -1,10 +1,7 @@
-#
-# Author:: Matt Ray (<matt@chef.io>)
-#
-# Copyright:: 2018, Chef Software, Inc <legal@chef.io>
-#
+# parses CloudFormation JSON files
 
 require 'json'
+
 require 'inspec/objects/control'
 require 'inspec/objects/ruby_helper'
 require 'inspec/objects/describe'
@@ -13,23 +10,14 @@ require 'inspec-iggy/inspec_helper'
 
 module InspecPlugins::Iggy::CloudFormation
   class Parser
+    # parse through the JSON and generate InSpec controls
     def self.parse_generate(file) # rubocop:disable all
-      Inspec::Log.debug "CloudFormation.parse_generate file = #{file}"
-      begin
-        unless File.file?(file)
-          STDERR.puts "ERROR: #{file} is an invalid file, please check your path."
-          exit(-1)
-        end
-        template = JSON.parse(File.read(file))
-      rescue JSON::ParserError => e
-        STDERR.puts e.message
-        STDERR.puts "ERROR: Parsing error in #{file}."
-        exit(-1)
-      end
+      template = parse_cfn(file)
       absolutename = File.absolute_path(file)
 
       # InSpec controls generated
       generated_controls = []
+
       # iterate over the resources
       cfn_resources = template['Resources']
       cfn_resources.keys.each do |cfn_res|
@@ -101,6 +89,22 @@ module InspecPlugins::Iggy::CloudFormation
       end
       Inspec::Log.debug "CloudFormation.parse_generate generated_controls = #{generated_controls}"
       generated_controls
+    end
+
+    # boilerplate JSON parsing
+    def self.parse_cfn(file)
+      Inspec::Log.debug "CloudFormation.parse_cfn file = #{file}"
+      begin
+        unless File.file?(file)
+          STDERR.puts "ERROR: #{file} is an invalid file, please check your path."
+          exit(-1)
+        end
+        JSON.parse(File.read(file))
+      rescue JSON::ParserError => e
+        STDERR.puts e.message
+        STDERR.puts "ERROR: Parsing error in #{file}."
+        exit(-1)
+      end
     end
   end
 end

--- a/lib/inspec-iggy/cloudformation/parser.rb
+++ b/lib/inspec-iggy/cloudformation/parser.rb
@@ -11,9 +11,8 @@ module InspecPlugins::Iggy::CloudFormation
   class Parser
     # parse through the JSON and generate InSpec controls
     def self.parse_generate(cfn_template)
-      file = InspecPlugins::Iggy::FileHelper.fetch(cfn_template)
-      template = InspecPlugins::Iggy::FileHelper.parse_json(file)
-      absolutename = File.absolute_path(file)
+      template = InspecPlugins::Iggy::FileHelper.parse_json(cfn_template)
+      absolutename = File.absolute_path(cfn_template)
 
       # InSpec controls generated
       generated_controls = []

--- a/lib/inspec-iggy/cloudformation/parser.rb
+++ b/lib/inspec-iggy/cloudformation/parser.rb
@@ -10,7 +10,8 @@ require 'inspec-iggy/inspec_helper'
 module InspecPlugins::Iggy::CloudFormation
   class Parser
     # parse through the JSON and generate InSpec controls
-    def self.parse_generate(file) # rubocop:disable all
+    def self.parse_generate(cfn_template)
+      file = InspecPlugins::Iggy::FileHelper.fetch(cfn_template)
       template = InspecPlugins::Iggy::FileHelper.parse_json(file)
       absolutename = File.absolute_path(file)
 
@@ -66,15 +67,15 @@ module InspecPlugins::Iggy::CloudFormation
                 if property.eql?('vpc_id') # rubocop:disable Metrics/BlockNesting
                   vpc = cfn_resources[cfn_res]['Properties'][attr].values.first
                   # https://github.com/inspec/inspec/issues/3173
-                  describe.add_test(property, 'eq', "resources[#{vpc}]") unless cfn_res_type.eql?('aws_route_table') # rubocop:disable Metrics/BlockNesting
+                  describe.add_test(property, 'cmp', "resources[#{vpc}]") unless cfn_res_type.eql?('aws_route_table') # rubocop:disable Metrics/BlockNesting
                   # AMI is a Ref into Parameters
                 elsif property.eql?('image_id') # rubocop:disable Metrics/BlockNesting
                   amiref = cfn_resources[cfn_res]['Properties'][attr].values.first
                   ami = template['Parameters'][amiref]['Default']
-                  describe.add_test(property, 'eq', ami)
+                  describe.add_test(property, 'cmp', ami)
                 end
               else
-                describe.add_test(property, 'eq', value)
+                describe.add_test(property, 'cmp', value)
               end
             else
               Inspec::Log.debug "CloudFormation.parse_generate #{cfn_res_type} inspec_property = #{property} SKIP"

--- a/lib/inspec-iggy/file_helper.rb
+++ b/lib/inspec-iggy/file_helper.rb
@@ -20,6 +20,17 @@ module InspecPlugins
           exit(-1)
         end
       end
+
+      def self.fetch(url)
+        temp_file = url
+        # if this is a file, just return it
+        # retrieve the file into a temp_file
+        # do all urls start with http:// https://
+        # is s3:// a thing?
+        # how else do CFN and Terraform store this?
+        return temp_file
+      end
+
     end
   end
 end

--- a/lib/inspec-iggy/file_helper.rb
+++ b/lib/inspec-iggy/file_helper.rb
@@ -25,16 +25,16 @@ module InspecPlugins
 
       def self.fetch(url)
         # if this is a file, just return it
-        return url if File.exists?(url)
+        return url if File.exist?(url)
+
         begin
-          open(url)
+          URI.parse(url).open
         rescue OpenURI::HTTPError => e
           STDERR.puts e.message
           STDERR.puts "ERROR: Parsing error from URL #{url}"
           exit(-1)
         end
       end
-
     end
   end
 end

--- a/lib/inspec-iggy/file_helper.rb
+++ b/lib/inspec-iggy/file_helper.rb
@@ -28,6 +28,7 @@ module InspecPlugins
         # do all urls start with http:// https://
         # is s3:// a thing?
         # how else do CFN and Terraform store this?
+        #  absolutename = File.absolute_path(file) will be broken for remote files
         return temp_file
       end
 

--- a/lib/inspec-iggy/file_helper.rb
+++ b/lib/inspec-iggy/file_helper.rb
@@ -1,0 +1,25 @@
+# helper methods for retrieving and parsing files
+
+require 'json'
+
+module InspecPlugins
+  module Iggy
+    class FileHelper
+      # boilerplate JSON parsing
+      def self.parse_json(file)
+        Inspec::Log.debug "Iggy::FileHelper.parse_json file = #{file}"
+        begin
+          unless File.file?(file)
+            STDERR.puts "ERROR: #{file} is an invalid file, please check your path."
+            exit(-1)
+          end
+          JSON.parse(File.read(file))
+        rescue JSON::ParserError => e
+          STDERR.puts e.message
+          STDERR.puts "ERROR: Parsing error in #{file}."
+          exit(-1)
+        end
+      end
+    end
+  end
+end

--- a/lib/inspec-iggy/inspec_helper.rb
+++ b/lib/inspec-iggy/inspec_helper.rb
@@ -13,7 +13,7 @@ module InspecPlugins
         'aws_instance' => 'aws_ec2_instance',
         'aws_v_p_c' => 'aws_vpc', # CFN
         'azurerm_resource_group' => 'azure_resource_group',
-        'azurerm_virtual_machine' => 'azure_virtual_machine',
+        'azurerm_virtual_machine' => 'azure_virtual_machine'
         # "azure_virtual_machine_data_disk",
         # 'aws_route' => 'aws_route_table' # needs route_table_id instead of id
       }.freeze

--- a/lib/inspec-iggy/inspec_helper.rb
+++ b/lib/inspec-iggy/inspec_helper.rb
@@ -1,8 +1,4 @@
-#
-# Author:: Matt Ray (<matt@chef.io>)
-#
-# Copyright:: 2018, Chef Software, Inc <legal@chef.io>
-#
+# constants and helpers for working with InSpec
 
 require 'inspec'
 
@@ -18,7 +14,7 @@ module InspecPlugins
         # 'aws_route' => 'aws_route_table' # needs route_table_id instead of id
       }.freeze
 
-      # # there really should be some way to get this directly from InSpec's resources
+      # there really should be some way to get this directly from InSpec's resources
       def self.resource_properties(resource)
         # remove the common methods, in theory only leaving only unique InSpec properties
         inspec_properties = Inspec::Resource.registry[resource].instance_methods - COMMON_PROPERTIES
@@ -27,20 +23,6 @@ module InspecPlugins
         Inspec::Log.debug "InspecHelper.resource_properties #{resource} properties = #{inspec_properties}"
 
         inspec_properties
-      end
-
-      def self.print_commands(extracted_profiles)
-        extracted_profiles.keys.each do |cmd|
-          type = extracted_profiles[cmd]['type']
-          url = extracted_profiles[cmd]['url']
-          key_name = extracted_profiles[cmd]['key_name']
-          if type == 'aws_instance'
-            ip = extracted_profiles[cmd]['public_ip']
-            puts "inspec exec #{url} -t ssh://#{ip} -i #{key_name}"
-          else
-            puts "inspec exec #{url} -t aws://us-west-2"
-          end
-        end
       end
 
       def self.tf_controls(title, generated_controls)
@@ -77,5 +59,20 @@ module InspecPlugins
       COMMON_PROPERTIES = Inspec::Resource.registry['aws_subnet'].instance_methods &
                           Inspec::Resource.registry['directory'].instance_methods
     end
+
+    # disabled extract functionality
+    # def self.print_commands(extracted_profiles)
+    #   extracted_profiles.keys.each do |cmd|
+    #     type = extracted_profiles[cmd]['type']
+    #     url = extracted_profiles[cmd]['url']
+    #     key_name = extracted_profiles[cmd]['key_name']
+    #     if type == 'aws_instance'
+    #       ip = extracted_profiles[cmd]['public_ip']
+    #       puts "inspec exec #{url} -t ssh://#{ip} -i #{key_name}"
+    #     else
+    #       puts "inspec exec #{url} -t aws://us-west-2"
+    #     end
+    #   end
+    # end
   end
 end

--- a/lib/inspec-iggy/inspec_helper.rb
+++ b/lib/inspec-iggy/inspec_helper.rb
@@ -11,6 +11,10 @@ module InspecPlugins
       # translate Terraform resource name to InSpec
       TRANSLATED_RESOURCES = {
         'aws_instance' => 'aws_ec2_instance',
+        'aws_v_p_c' => 'aws_vpc', # CFN
+        'azurerm_resource_group' => 'azure_resource_group',
+        'azurerm_virtual_machine' => 'azure_virtual_machine',
+        # "azure_virtual_machine_data_disk",
         # 'aws_route' => 'aws_route_table' # needs route_table_id instead of id
       }.freeze
 

--- a/lib/inspec-iggy/plugin.rb
+++ b/lib/inspec-iggy/plugin.rb
@@ -1,30 +1,17 @@
-# encoding: UTF-8
-
-# Plugin Definition file
-# The purpose of this file is to declare to InSpec what plugin_types (capabilities)
-# are included in this plugin, and provide hooks that will load them as needed.
-
-# It is important that this file load successfully and *quickly*.
-# Your plugin's functionality may never be used on this InSpec run; so we keep things
-# fast and light by only loading heavy things when they are needed.
-
 require 'inspec/plugin/v2'
 
 # The InspecPlugins namespace is where all plugins should declare themselves.
 # The 'Inspec' capitalization is used throughout the InSpec source code; yes, it's
 # strange.
 module InspecPlugins
-  # Pick a reasonable namespace here for your plugin.  A reasonable choice
-  # would be the CamelCase version of your plugin gem name.
   module Iggy
     class Plugin < ::Inspec.plugin(2)
       # Internal machine name of the plugin. InSpec will use this in errors, etc.
       plugin_name :'inspec-iggy'
 
       cli_command :terraform do
-        # Calling this hook doesn't mean iggy is being executed - just
-        # that we should be ready to do so. So, load the file that defines the
-        # functionality.
+        # Calling this hook doesn't mean iggy is being executed - just that we
+        # should be ready to do so. So, load the file that defines the functionality.
         # For example, InSpec will activate this hook when `inspec help` is
         # executed, so that this plugin's usage message will be included in the help.
         require 'inspec-iggy/terraform/cli_command'

--- a/lib/inspec-iggy/profile.rb
+++ b/lib/inspec-iggy/profile.rb
@@ -1,9 +1,4 @@
-# -*- coding: utf-8 -*-
-#
-# Author:: Matt Ray (<matt@chef.io>)
-#
-# Copyright:: 2018, Chef Software, Inc <legal@chef.io>
-#
+# renders the profile from the parsed files
 
 require 'yaml'
 
@@ -61,7 +56,7 @@ module InspecPlugins
         f.close
       end
 
-      #  * Create file controls/example.rb
+      #  * Create file controls/controls.rb
       def self.render_controls_rb(cli_ui, name, controls)
         render_file = "#{name}/controls/controls.rb"
         cli_ui.li "Create file #{cli_ui.mark_text(render_file)}"

--- a/lib/inspec-iggy/profile_helper.rb
+++ b/lib/inspec-iggy/profile_helper.rb
@@ -4,7 +4,7 @@ require 'yaml'
 
 module InspecPlugins
   module Iggy
-    class Profile
+    class ProfileHelper
       # match the output of 'inspec init profile'
       def self.render_profile(cli_ui, options, source_file, controls)
         name = options[:name]

--- a/lib/inspec-iggy/terraform/cli_command.rb
+++ b/lib/inspec-iggy/terraform/cli_command.rb
@@ -1,9 +1,4 @@
-# encoding: utf-8
-#
-# Author:: Matt Ray (<matt@chef.io>)
-#
-# Copyright:: 2018, Chef Software, Inc <legal@chef.io>
-#
+# Terraform CLI command and options
 
 require 'inspec/plugin/v2'
 
@@ -14,7 +9,7 @@ require 'inspec-iggy/terraform/parser'
 module InspecPlugins::Iggy
   module Terraform
     class CliCommand < Inspec.plugin(2, :cli_command)
-      subcommand_desc 'terraform SUBCOMMAND ...', 'Extract or generate InSpec from Terraform'
+      subcommand_desc 'terraform SUBCOMMAND ...', 'Generate an InSpec profile from Terraform'
 
       # Thor.map(Hash) allows you to make aliases for commands.
       map('-v' => 'version')         # Treat `inspec terraform -v`` as `inspec terraform version`
@@ -82,13 +77,14 @@ module InspecPlugins::Iggy
         exit 0
       end
 
-      desc 'extract [options]', 'Extract tagged InSpec profiles from terraform.tfstate'
-      def extract
-        Inspec::Log.level = :debug if options[:debug]
-        extracted_profiles = InspecPlugins::Iggy::Terraform::Parser.parse_extract(options[:tfstate])
-        puts InspecPlugins::Iggy::InspecHelper.print_commands(extracted_profiles)
-        exit 0
-      end
+      # disabled extract functionality
+      # desc 'extract [options]', 'Extract tagged InSpec profiles from terraform.tfstate'
+      # def extract
+      #   Inspec::Log.level = :debug if options[:debug]
+      #   extracted_profiles = InspecPlugins::Iggy::Terraform::Parser.parse_extract(options[:tfstate])
+      #   puts InspecPlugins::Iggy::InspecHelper.print_commands(extracted_profiles)
+      #   exit 0
+      # end
     end
   end
 end

--- a/lib/inspec-iggy/terraform/cli_command.rb
+++ b/lib/inspec-iggy/terraform/cli_command.rb
@@ -3,7 +3,7 @@
 require 'inspec/plugin/v2'
 
 require 'inspec-iggy/version'
-require 'inspec-iggy/profile'
+require 'inspec-iggy/profile_helper'
 require 'inspec-iggy/terraform/parser'
 
 module InspecPlugins::Iggy
@@ -73,7 +73,7 @@ module InspecPlugins::Iggy
         Inspec::Log.level = :debug if options[:debug]
         generated_controls = InspecPlugins::Iggy::Terraform::Parser.parse_generate(options[:tfstate])
         printable_controls = InspecPlugins::Iggy::InspecHelper.tf_controls(options[:title], generated_controls)
-        InspecPlugins::Iggy::Profile.render_profile(self, options, options[:tfstate], printable_controls)
+        InspecPlugins::Iggy::ProfileHelper.render_profile(self, options, options[:tfstate], printable_controls)
         exit 0
       end
 

--- a/lib/inspec-iggy/terraform/parser.rb
+++ b/lib/inspec-iggy/terraform/parser.rb
@@ -15,7 +15,7 @@ module InspecPlugins::Iggy::Terraform
     # TAG_URL = 'iggy_url_'.freeze
 
     # parse through the JSON and generate InSpec controls
-    def self.parse_generate(tf_file) # rubocop:disable all
+    def self.parse_generate(tf_file) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
       tfstate = InspecPlugins::Iggy::FileHelper.parse_json(tf_file)
       absolutename = File.absolute_path(tf_file)
 
@@ -49,16 +49,16 @@ module InspecPlugins::Iggy::Terraform
             describe = Inspec::Describe.new
             # describes the resource with the name as argument
             # this is a hack for azure, we need a better longterm solution
-            if tf_res_type.start_with?("azure_")
-              name = tf_res_id.split("/").last
+            if tf_res_type.start_with?('azure_')
+              name = tf_res_id.split('/').last
             else
               name = tf_res_id
             end
 
             # describes the resource with the id as argument
             # going to need to move the special Azure code out, and add helpers for each provider
-            if tf_res_type.start_with?("azure_")
-              if tf_res_type.eql?("azure_resource_group")
+            if tf_res_type.start_with?('azure_')
+              if tf_res_type.eql?('azure_resource_group')
                 describe.qualifier.push([tf_res_type, name: name])
               else
                 resource_group = tf_res_id.split('resourceGroups/').last.split('/').first
@@ -69,12 +69,12 @@ module InspecPlugins::Iggy::Terraform
             end
 
             # ensure the resource exists unless Azure, which currently doesn't support it as of InSpec 2.2
-            describe.add_test(nil, "exist", nil) unless tf_res_type.start_with?("azure_")
+            describe.add_test(nil, 'exist', nil) unless tf_res_type.start_with?('azure_')
 
             # if there's a match, see if there are matching InSpec properties
             inspec_properties = InspecPlugins::Iggy::InspecHelper.resource_properties(tf_res_type)
             # push stuff back into inspec_properties?
-            inspec_properties.push('name') if tf_res_type.start_with?("azure_")
+            inspec_properties.push('name') if tf_res_type.start_with?('azure_')
             tf_resources[tf_res]['primary']['attributes'].keys.each do |attr|
               if inspec_properties.member?(attr)
                 Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} MATCHED"

--- a/lib/inspec-iggy/terraform/parser.rb
+++ b/lib/inspec-iggy/terraform/parser.rb
@@ -1,11 +1,10 @@
 # parses Terraform d.tfstate files
 
-require 'json'
-
 require 'inspec/objects/control'
 require 'inspec/objects/ruby_helper'
 require 'inspec/objects/describe'
 
+require 'inspec-iggy/file_helper'
 require 'inspec-iggy/inspec_helper'
 
 module InspecPlugins::Iggy::Terraform
@@ -17,7 +16,7 @@ module InspecPlugins::Iggy::Terraform
 
     # parse through the JSON and generate InSpec controls
     def self.parse_generate(file) # rubocop:disable all
-      tfstate = parse_tfstate(file)
+      tfstate = InspecPlugins::Iggy::FileHelper.parse_json(file)
       absolutename = File.absolute_path(file)
 
       # InSpec controls generated
@@ -75,22 +74,6 @@ module InspecPlugins::Iggy::Terraform
       end
       Inspec::Log.debug "Iggy::Terraform.parse_generate generated_controls = #{generated_controls}"
       generated_controls
-    end
-
-    # boilerplate JSON parsing
-    def self.parse_tfstate(file)
-      Inspec::Log.debug "Iggy::Terraform.parse_tfstate file = #{file}"
-      begin
-        unless File.file?(file)
-          STDERR.puts "ERROR: #{file} is an invalid file, please check your path."
-          exit(-1)
-        end
-        JSON.parse(File.read(file))
-      rescue JSON::ParserError => e
-        STDERR.puts e.message
-        STDERR.puts "ERROR: Parsing error in #{file}."
-        exit(-1)
-      end
     end
 
     # disabled extract functionality

--- a/lib/inspec-iggy/terraform/parser.rb
+++ b/lib/inspec-iggy/terraform/parser.rb
@@ -15,7 +15,8 @@ module InspecPlugins::Iggy::Terraform
     # TAG_URL = 'iggy_url_'.freeze
 
     # parse through the JSON and generate InSpec controls
-    def self.parse_generate(file) # rubocop:disable all
+    def self.parse_generate(tf_file) # rubocop:disable all
+      file = InspecPlugins::Iggy::FileHelper.fetch(tf_file)
       tfstate = InspecPlugins::Iggy::FileHelper.parse_json(file)
       absolutename = File.absolute_path(file)
 
@@ -59,7 +60,7 @@ module InspecPlugins::Iggy::Terraform
               if inspec_properties.member?(attr)
                 Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} MATCH"
                 value = tf_resources[tf_res]['primary']['attributes'][attr]
-                describe.add_test(attr, 'eq', value)
+                describe.add_test(attr, 'cmp', value)
               else
                 Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} SKIP"
               end

--- a/lib/inspec-iggy/terraform/parser.rb
+++ b/lib/inspec-iggy/terraform/parser.rb
@@ -37,7 +37,7 @@ module InspecPlugins::Iggy::Terraform
 
           # does this match an InSpec resource?
           if InspecPlugins::Iggy::InspecHelper::RESOURCES.include?(tf_res_type)
-            Inspec::Log.debug "Iggy::Terraform.parse_generate tf_res_type = #{tf_res_type} MATCH"
+            Inspec::Log.debug "Iggy::Terraform.parse_generate tf_res_type = #{tf_res_type} MATCHED"
             tf_res_id = tf_resources[tf_res]['primary']['id']
 
             # insert new control based off the resource's ID
@@ -58,18 +58,18 @@ module InspecPlugins::Iggy::Terraform
             inspec_properties = InspecPlugins::Iggy::InspecHelper.resource_properties(tf_res_type)
             tf_resources[tf_res]['primary']['attributes'].keys.each do |attr|
               if inspec_properties.member?(attr)
-                Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} MATCH"
+                Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} MATCHED"
                 value = tf_resources[tf_res]['primary']['attributes'][attr]
                 describe.add_test(attr, 'cmp', value)
               else
-                Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} SKIP"
+                Inspec::Log.debug "Iggy::Terraform.parse_generate #{tf_res_type} inspec_property = #{attr} SKIPPED"
               end
             end
 
             ctrl.add_test(describe)
             generated_controls.push(ctrl)
           else
-            Inspec::Log.debug "Iggy::Terraform.parse_generate tf_res_type = #{tf_res_type} SKIP"
+            Inspec::Log.debug "Iggy::Terraform.parse_generate tf_res_type = #{tf_res_type} SKIPPED"
           end
         end
       end

--- a/lib/inspec-iggy/terraform/parser.rb
+++ b/lib/inspec-iggy/terraform/parser.rb
@@ -16,9 +16,8 @@ module InspecPlugins::Iggy::Terraform
 
     # parse through the JSON and generate InSpec controls
     def self.parse_generate(tf_file) # rubocop:disable all
-      file = InspecPlugins::Iggy::FileHelper.fetch(tf_file)
-      tfstate = InspecPlugins::Iggy::FileHelper.parse_json(file)
-      absolutename = File.absolute_path(file)
+      tfstate = InspecPlugins::Iggy::FileHelper.parse_json(tf_file)
+      absolutename = File.absolute_path(tf_file)
 
       # InSpec controls generated
       generated_controls = []

--- a/lib/inspec-iggy/version.rb
+++ b/lib/inspec-iggy/version.rb
@@ -1,11 +1,7 @@
-# encoding: UTF-8
-#
-# Author:: Matt Ray (<matt@chef.io>)
-#
-# Copyright:: 2018, Chef Software, Inc <legal@chef.io>
-#
+# provide the version for the plugin
+
 module InspecPlugins
   module Iggy
-    VERSION = '0.4.0'.freeze
+    VERSION = '0.5.0'.freeze
   end
 end

--- a/test/functional/cloudformation_spec.rb
+++ b/test/functional/cloudformation_spec.rb
@@ -37,7 +37,7 @@ module IggyFunctionalTests
       assert(check_json['summary']['valid'])
       assert_empty(check_json['errors'])
       assert_empty(check_json['warnings'])
-      assert_equal(15, check_json['summary']['controls'])
+      assert_equal(16, check_json['summary']['controls'])
 
       # TODO: many many tests could be done here
       export_json = iggy_run_result.payload.export_json

--- a/test/unit/terraform_cli_args_spec.rb
+++ b/test/unit/terraform_cli_args_spec.rb
@@ -18,7 +18,6 @@ module IggyUnitTests
 
     def commands
       [
-        'extract',
         'generate',
         'help',
         'version',
@@ -135,25 +134,25 @@ module IggyUnitTests
     end
   end
 
-  class ExtractCommand < Minitest::Test
-    include TfLets
+  # class ExtractCommand < Minitest::Test
+  #   include TfLets
 
-    def all_options
-      []
-    end
+  #   def all_options
+  #     []
+  #   end
 
-    def extract_options
-      cli_class.all_commands['extract'].options
-    end
+  #   def extract_options
+  #     cli_class.all_commands['extract'].options
+  #   end
 
-    def test_it_should_have_the_correct_option_count
-      assert_equal(all_options.count, extract_options.count)
-    end
+  #   def test_it_should_have_the_correct_option_count
+  #     assert_equal(all_options.count, extract_options.count)
+  #   end
 
-    # Argument count
-    # The 'generate' command does not accept arguments.
-    def test_it_should_take_no_arguments
-      assert_equal(0, cli_class.instance_method(:generate).arity)
-    end
-  end
+  #   # Argument count
+  #   # The 'generate' command does not accept arguments.
+  #   def test_it_should_take_no_arguments
+  #     assert_equal(0, cli_class.instance_method(:generate).arity)
+  #   end
+  # end
 end


### PR DESCRIPTION
* moved back to https://github.com/mattray/inspec-iggy as a community plugin
* provide DESIGN.md explaining the organization of the code
* disabled the `inspec terraform extract` subcommand until a more sustainable solution is determined
* rename lib/inspec-iggy/profile.rb to profile_helper.rb
* switch from 'eq' to 'cmp' comparators https://github.com/mattray/inspec-iggy/issues/23
* enable minimal Azure support. This needs to be refactored with support for Resource Packs.
* refactor out JSON parsing into file_helper.rb
* add support for remote .tfstate and .cfn files via Iggy::FileHelper.fetch https://github.com/mattray/inspec-iggy/issues/3
* Sync and upgrade InSpec's .rubocop.yml and associated code cleanups
